### PR TITLE
ignore IFlowxxx Test classes when Jvm is not 1.7d

### DIFF
--- a/tests/checkers/inference/IFlowSinkPropTest.java
+++ b/tests/checkers/inference/IFlowSinkPropTest.java
@@ -26,7 +26,9 @@ public class IFlowSinkPropTest extends CFInferenceTest {
     @Parameters
     public static List<File> getTestFiles(){
         List<File> testfiles = new ArrayList<>();//InferenceTestUtilities.findAllSystemTests();
-        testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsink"));
+        if(is7Jvm) {
+            testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsink"));
+        }
         return testfiles;
     }
 }

--- a/tests/checkers/inference/IFlowSinkSatTest.java
+++ b/tests/checkers/inference/IFlowSinkSatTest.java
@@ -26,7 +26,9 @@ public class IFlowSinkSatTest extends CFInferenceTest {
     @Parameters
     public static List<File> getTestFiles(){
         List<File> testfiles = new ArrayList<>();//InferenceTestUtilities.findAllSystemTests();
-        testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsink"));
+        if(is7Jvm) {
+            testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsink"));
+        }
         return testfiles;
     }
 }

--- a/tests/checkers/inference/IFlowSourcePropTest.java
+++ b/tests/checkers/inference/IFlowSourcePropTest.java
@@ -26,7 +26,9 @@ public class IFlowSourcePropTest extends CFInferenceTest {
     @Parameters
     public static List<File> getTestFiles(){
         List<File> testfiles = new ArrayList<>();//InferenceTestUtilities.findAllSystemTests();
-        testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsource"));
+        if(is7Jvm) {
+            testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsource"));    
+        }
         return testfiles;
     }
 }

--- a/tests/checkers/inference/IFlowSourceSatTest.java
+++ b/tests/checkers/inference/IFlowSourceSatTest.java
@@ -26,7 +26,9 @@ public class IFlowSourceSatTest extends CFInferenceTest {
     @Parameters
     public static List<File> getTestFiles(){
         List<File> testfiles = new ArrayList<>();//InferenceTestUtilities.findAllSystemTests();
-        testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsource"));
+        if(is7Jvm) {
+            testfiles.addAll(TestUtilities.findRelativeNestedJavaFiles("testdata", "iflowsource"));    
+        }
         return testfiles;
     }
 }

--- a/tests/checkers/inference/test/CFInferenceTest.java
+++ b/tests/checkers/inference/test/CFInferenceTest.java
@@ -14,6 +14,12 @@ import org.junit.Test;
 
 public abstract class CFInferenceTest extends CheckerFrameworkTest {
 
+    public static final boolean is7Jvm;
+
+    static {
+        is7Jvm = org.checkerframework.framework.util.PluginUtil.getJreVersion() == 1.7d;
+    }
+
     public CFInferenceTest(File testFile, Class<? extends AbstractProcessor> checker,
                            String checkerDir, String... checkerOptions) {
         super(testFile, checker, checkerDir, checkerOptions);


### PR DESCRIPTION
Add static final boolean `is7Jvm`in `CFInferenceTest`

Add check of this boolean in `getTestFiles()` of `IFlowxxxTest` classes to return empty test files set if Jvm version is not equal to 1.7d.
